### PR TITLE
Fix socat binary path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:24.04
 ENV user=user
 ENV chall_port=1337
 ENV chall_name=chall_bof
+ENV chall_name_bin=binexp_bof_01
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt update

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-socat -T 10 TCP-LISTEN:$chall_port,reuseaddr,fork EXEC:/root/$chall_name &
+socat -T 10 TCP-LISTEN:$chall_port,reuseaddr,fork EXEC:/root/$chall_name/$chall_name_bin &
 python3 -m http.server 8000


### PR DESCRIPTION
Previously I wasn't using `chall_bof` directory but when changed to it I forget to add it on docker-entrypoint.sh.